### PR TITLE
Weighted dragon spawning

### DIFF
--- a/Dragon Dermatology/Assets/Scripts/Dragons/Dragon.cs
+++ b/Dragon Dermatology/Assets/Scripts/Dragons/Dragon.cs
@@ -23,31 +23,17 @@ public class Dragon : MonoBehaviour
     // Settings
     ///////////////////////////////////////////////
 
-    [Tooltip("The kind of dragon.")]
-    public Species species;
-
-    [Tooltip("Indicates where the dragon is within the salon building.")]
-    public Mode initialMode;
-
-    [Range(0, 1)]
-    [Tooltip("The desired cleanliness as a percentage between 0-1.")]
-    public float desiredCleanliness;
-
-    [Range(0, 1)]
-    [Tooltip("The desired polish as a percentage between 0-1.")]
-    public float desiredPolish;
-
-    public int minCoinsIfClean;
-    public int maxCoinsIfClean;
-    public int minCoinsIfProud;
-    public int maxCoinsIfProud;
-
-
     [Tooltip("Reference to the child object which renders the queued dragon.")]
     public GameObject queueRenderObject;
 
     [Tooltip("Reference to the child object which renders the in-salon dragon.")]
     public GameObject salonRenderObject;
+
+    ///////////////////////////////////////////////
+    // Init
+    ///////////////////////////////////////////////
+
+    public Species Species { get; set; }
 
     ///////////////////////////////////////////////
     // State
@@ -60,11 +46,8 @@ public class Dragon : MonoBehaviour
     private float polishPercent;
     private int numSuds;
 
-    // Unused - placeholders
-    //private List<DragonScale> scales;
-    //private float happiness;
-    //private float stealth;
-    //private int coins;
+    private float desiredCleanliness = 1f;
+    private float desiredPolish = 1f;
 
     ///////////////////////////////////////////////
     // Behaviour
@@ -72,7 +55,7 @@ public class Dragon : MonoBehaviour
 
     void Start()
     {
-        SetMode(initialMode);
+        SetMode(Mode.Queued);
     }
 
     public void SetMode(Mode mode)
@@ -95,8 +78,8 @@ public class Dragon : MonoBehaviour
 
     public int AskForPayment()
     {
-        return (IsFeelingClean ? UnityEngine.Random.Range(minCoinsIfClean, maxCoinsIfClean) : 0) +
-                (IsFeelingProud ? UnityEngine.Random.Range(minCoinsIfProud, maxCoinsIfProud) : 0);
+        return (IsFeelingClean ? DragonTraits.CoinsIfClean[Species] : 0) +
+                (IsFeelingProud ? DragonTraits.CoinsIfPolished[Species] : 0);
     }
 
     public void SetCleanlinessPercent(float percent) {

--- a/Dragon Dermatology/Assets/Scripts/Dragons/DragonTraits.cs
+++ b/Dragon Dermatology/Assets/Scripts/Dragons/DragonTraits.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+
+public static class DragonTraits {
+    // Cleanliness preferences
+    public static readonly Dictionary<Species, float> CleanPreference = new Dictionary<Species, float> {
+        [Species.Regular] = 0.5f,
+        [Species.Water]   = 0.65f,
+        [Species.Fire]    = 0.8f
+    };
+
+    // Polish preferences
+    public static readonly Dictionary<Species, float> PolishPreference = new Dictionary<Species, float> {
+        [Species.Regular] = 0.25f,
+        [Species.Water]   = 0.5f,
+        [Species.Fire]    = 0.8f
+    };
+
+    // The coins to pay if clean
+    public static readonly Dictionary<Species, int> CoinsIfClean = new Dictionary<Species, int> {
+        [Species.Regular] = 2,
+        [Species.Water]   = 3,
+        [Species.Fire]    = 4
+    };
+
+    // The coins to pay if polished
+    public static readonly Dictionary<Species, int> CoinsIfPolished = new Dictionary<Species, int> {
+        [Species.Regular] = 3,
+        [Species.Water]   = 4,
+        [Species.Fire]    = 5
+    };
+}

--- a/Dragon Dermatology/Assets/Scripts/Dragons/DragonTraits.cs.meta
+++ b/Dragon Dermatology/Assets/Scripts/Dragons/DragonTraits.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f83ae9155e5ca174eb73bb00126c48d2

--- a/Dragon Dermatology/Assets/Scripts/Progression.meta
+++ b/Dragon Dermatology/Assets/Scripts/Progression.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d5b5b417e0468a042870607982bd8239
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Dragon Dermatology/Assets/Scripts/Progression/DailyRules.cs
+++ b/Dragon Dermatology/Assets/Scripts/Progression/DailyRules.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+public static class DailyRules {
+    // The likelihood of each kind of dragon spawning on a day. If a day isn't listed, dragons have equal weight.
+    // Regular, Water, Fire
+    private static readonly Dictionary<int, int[]> SpawnWeightsByDay = new Dictionary<int, int[]> {
+        [1] = new int[] { 1, 0, 0 },
+        [2] = new int[] { 2, 1, 0 },
+        [3] = new int[] { 2, 2, 1 }
+    };
+
+    // Regular, Water, Fire
+    public static int[] SpawnWeights(int day)
+    {
+        int[] weights;
+        if (!SpawnWeightsByDay.TryGetValue(day, out weights)) {
+            weights = new int[] { 1, 1, 1 };
+        }
+
+        return weights;
+    }
+}

--- a/Dragon Dermatology/Assets/Scripts/Progression/DailyRules.cs.meta
+++ b/Dragon Dermatology/Assets/Scripts/Progression/DailyRules.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 583266f75e64d234ea39dd8a919a8c1b

--- a/Dragon Dermatology/Assets/Scripts/Utils.meta
+++ b/Dragon Dermatology/Assets/Scripts/Utils.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f7328c1600fbfe64dbd04ddc8e1a87b1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Dragon Dermatology/Assets/Scripts/Utils/WeightedRandom.cs
+++ b/Dragon Dermatology/Assets/Scripts/Utils/WeightedRandom.cs
@@ -1,0 +1,30 @@
+using System;
+using UnityEngine;
+
+public static class WeightedRandom {
+
+    /// <summary>
+    /// Randomly return an index from this array. Indices are weighted by their array value, making them more likely to
+    /// be selected.
+    /// </summary>
+    public static int Index(int[] weights)
+    {
+        int sum = 0;
+        foreach (int w in weights) {
+            sum += w;
+        }
+
+        float r = UnityEngine.Random.value * sum;
+
+        float v = 0;
+        for (int i = 0; i < weights.Length; i++) {
+            v += weights[i];
+            if (v >= r) {
+                return i;
+            }
+        }
+
+        // We should never get here
+        throw new Exception("WeightedSelection somehow did not find a value.");
+    }
+}

--- a/Dragon Dermatology/Assets/Scripts/Utils/WeightedRandom.cs.meta
+++ b/Dragon Dermatology/Assets/Scripts/Utils/WeightedRandom.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 374f1724b7396174c96ccf191e03f871


### PR DESCRIPTION
This configures it so that only `Regular` dragons spawn on the first day. Then `Water` dragons start appearing on the second day, and `Fire` dragon on the third. From then on they have equal weighting.

Also the payout has been set so that `Fire` dragons pay the most, followed by `Water` then `Regular`. However they are also the hardest to please with cleaning polishing.